### PR TITLE
Added ability to control virtkvm with hotkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,21 @@ virtkvm:
 
 hotkey:
 	$(CC) main.cpp rs232.c misc.cpp -o virtkvm -Dwatch_port $(CFLAGS)
-	echo "[Unit]" > etc/virtkvm_alt.service
-	echo "Description=Virtual KVM" >> etc/virtkvm_alt.service
-	echo "" >> etc/virtkvm_alt.service
-	echo "[Service]" >> etc/virtkvm_alt.service
-	echo "ExecStart=/usr/local/bin/virtkvm -p=$PORT -i=$IP --daemon" >> etc/virtkvm_alt.service
-	echo "[Install]" >> etc/virtkvm_alt.service
-	echo "WantedBy=multi-user.target" >> etc/virtkvm_alt.service
 
 clean:
 	rm virtkvm -f
 
 install:
 	cp -f virtkvm /usr/local/bin
-	cp -f etc/virtkvm.service /etc/systemd/system/
 	chmod 755 /usr/local/bin/virtkvm
-
-install_hotkey:
-	cp -f virtkvm /usr/local/bin
-	cp -f etc/virtkvm_alt.service /etc/systemd/system/virtkvm.service
-	chmod 755 /usr/local/bin/virtkvm
+	if [ ${IP} ]; then \
+		if [ ! ${PORT} ]; then "PORT not defined"; exit; fi; \
+		export PORT=${PORT}; \
+		export IP=${IP}; \
+		bash add_args_to_service.sh > /etc/systemd/system/virtkvm.service; \
+	else \
+		cp -f etc/virtkvm.service /etc/systemd/system/; \
+	fi
 
 uninstall:
 	rm -f /usr/local/bin/virtkvm

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ install:
 		export PORT=${PORT}; \
 		export IP=${IP}; \
 		bash add_args_to_service.sh > /etc/systemd/system/virtkvm.service; \
+		cp -f virtkvm_client.py /usr/local/bin; \
+		chmod 755 /usr/local/bin/virtkvm_client.py; \
 	else \
 		cp -f etc/virtkvm.service /etc/systemd/system/; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ virtkvm:
 
 hotkey:
 	$(CC) main.cpp rs232.c misc.cpp -o virtkvm -Dwatch_port $(CFLAGS)
+	echo "[Unit]" > etc/virtkvm_alt.service
+	echo "Description=Virtual KVM" >> etc/virtkvm_alt.service
+	echo "" >> etc/virtkvm_alt.service
+	echo "[Service]" >> etc/virtkvm_alt.service
+	echo "ExecStart=/usr/local/bin/virtkvm -p=$PORT -i=$IP --daemon" >> etc/virtkvm_alt.service
+	echo "[Install]" >> etc/virtkvm_alt.service
+	echo "WantedBy=multi-user.target" >> etc/virtkvm_alt.service
 
 clean:
 	rm virtkvm -f
@@ -15,6 +22,11 @@ clean:
 install:
 	cp -f virtkvm /usr/local/bin
 	cp -f etc/virtkvm.service /etc/systemd/system/
+	chmod 755 /usr/local/bin/virtkvm
+
+install_hotkey:
+	cp -f virtkvm /usr/local/bin
+	cp -f etc/virtkvm_alt.service /etc/systemd/system/virtkvm.service
 	chmod 755 /usr/local/bin/virtkvm
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ CFLAGS=-I. -w
 virtkvm:
 	$(CC) main.cpp rs232.c misc.cpp -o virtkvm $(CFLAGS)
 
+hotkey:
+	$(CC) main.cpp rs232.c misc.cpp -o virtkvm -Dwatch_port $(CFLAGS)
+
 clean:
 	rm virtkvm -f
 

--- a/add_args_to_service.sh
+++ b/add_args_to_service.sh
@@ -1,0 +1,9 @@
+IFS='='
+while read line; do
+	read -r -a array <<< "$line";
+	if [ "${array[0]}" = "ExecStart" ]; then
+		echo -ne "$line -p=$PORT -i=$IP\n";
+	else
+		echo -ne "$line\n"
+	fi
+done < etc/virtkvm.service

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,2 +1,10 @@
 # virtkvm
 A virtual KVM-switch. Utilizes Arduino to attach and detach devices from libvirt.
+
+### Configure for hotkeys
+
+You can build it as is to respond to a Arduino push button, or you can map it to a hotkey combination using the steps below.
+
+1) Build project with `make hotkey PORT=1234 IP=10.0.0.12`. Port is arbitrary, but IP should be your host's IP address
+on the network facing your VM. If you are unsure, using 0.0.0.0 here will always work, but is less secure.
+2) Configure the client programs on your host and guest machines to use this port and ip address

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,14 +3,18 @@ A virtual KVM-switch. Utilizes Arduino to attach and detach devices from libvirt
 
 ### Configure for hotkeys
 
-You can build it as is to respond to a Arduino push button, or you can map it to a hotkey combination using the steps below.
+You can build it as-is to respond to a Arduino push button, or you can map it to a hotkey combination using the steps below.
 
 1) Build project with `make hotkey`. Compiling like this will disable the arduino hotkey, and instead the server will
 listen on a TCP port (Port 5555 on all networks by default)
-2) It's recommended you specify a new IP address on your VM's subnet. Otherwise any device on your LAN can toggle your
-mouse and keyboard. Add flags to the command make install command, like `sudo make install IP=10.1.1.10 PORT=56789`,
-where 10.1.1.10 is your host's IP address on the network facing your VM, and PORT is an arbitrary number between 1024
-and 65535.
-3) Set up your client programs to point to the correct IP address your server is using. Even if you skipped the step
-above and your server is running on all networks, your client still requires an IP address. If you skipped the step
-above, the default port number is 5555.
+2) Open virtkvm_client.py and edit the HOST and PORT lines. Port can be any arbitary port, but it's recommended you
+change to the IP address on your host-vm subnet. Leaving the IP address as 0.0.0.0 means anyone on your LAN can toggle
+your mouse and keyboard.
+3) Using the IP address and port above, add flags to the command make install command, like
+`sudo make install IP=10.1.1.10 PORT=56789`, where 10.1.1.10 is your host's IP address on the network facing your VM.
+4) The installation automatically copies the client file on your host. You can run it by typing virtkvm_client.py in a
+bash shell. See documentation for your specific desktop environment for how to set up a hotkey.
+5) You will have to manually copy the script to your guest. If you put a shortcut to the script on a Windows desktop,
+you can right click the icon, select properties, and under shortcut there will be an option to map a hotkey. You will
+also need to install python on your windows machine for it to work. A java alternative should be easy to make, but I'm
+having issues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,12 @@ A virtual KVM-switch. Utilizes Arduino to attach and detach devices from libvirt
 
 You can build it as is to respond to a Arduino push button, or you can map it to a hotkey combination using the steps below.
 
-1) Build project with `make hotkey PORT=1234 IP=10.0.0.12`. Port is arbitrary, but IP should be your host's IP address
-on the network facing your VM. If you are unsure, using 0.0.0.0 here will always work, but is less secure.
-2) Use the custom install option `sudo make install_hotkey`
-2) Configure the client programs on your host and guest machines to use the same port and ip address
+1) Build project with `make hotkey`. Compiling like this will disable the arduino hotkey, and instead the server will
+listen on a TCP port (Port 5555 on all networks by default)
+2) It's recommended you specify a new IP address on your VM's subnet. Otherwise any device on your LAN can toggle your
+mouse and keyboard. Add flags to the command make install command, like `sudo make install IP=10.1.1.10 PORT=56789`,
+where 10.1.1.10 is your host's IP address on the network facing your VM, and PORT is an arbitrary number between 1024
+and 65535.
+3) Set up your client programs to point to the correct IP address your server is using. Even if you skipped the step
+above and your server is running on all networks, your client still requires an IP address. If you skipped the step
+above, the default port number is 5555.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ You can build it as is to respond to a Arduino push button, or you can map it to
 
 1) Build project with `make hotkey PORT=1234 IP=10.0.0.12`. Port is arbitrary, but IP should be your host's IP address
 on the network facing your VM. If you are unsure, using 0.0.0.0 here will always work, but is less secure.
-2) Configure the client programs on your host and guest machines to use this port and ip address
+2) Use the custom install option `sudo make install_hotkey`
+2) Configure the client programs on your host and guest machines to use the same port and ip address

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ main(int argc, char *argv[])
 	int i = 0, size = 32;
 	char mode[] = { '8', 'N', '1', '\0' };
 	unsigned char buf[size];
-	unsigned char ipaddr[] = {127,0,0,1};     // The address to listen on
+	unsigned char ipaddr[] = {0,0,0,0};     // The address to listen on
     unsigned short port = 5555;            // The port to listen on
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@
 #include "misc.h"
 #include "config.h"
 
-#define PORT 38808
+#define PORT 57831
 #define BUFLEN 16
 
 // Create .xml for libvirt.
@@ -79,23 +79,10 @@ main(int argc, char *argv[])
 
 	CreateXMLFiles();
 
-//	if(RS232_OpenComport(port, baudRate, mode))
-//	{
-//		std::cout << "Could not access serial port!\nDid you run as root?" << std::endl;
-//		return 1;
-//	}
-//	if ( popenCmd ( "sudo virsh list --all | grep " + vmName ).find ( "shut off" ) != std::string::npos ) {
-//		for(int i = 0; i < argc; i++) {
-//			if(argv[i] == "--daemonize") {
-//				std::cout << "[*] ERROR: VM \'" + vmName + "\' is not running.";
-//				return 1;
-//			}
-//		}
-//	}
-
     // TODO: Listen for argument here to specify IP address or network device to bind to, so only your VM can toggle
     // the KVM and not any rando on your WiFi
 
+#ifdef watch_port
     int socket_info;
     struct sockaddr_in server;
     socklen_t servlen = sizeof(server);
@@ -132,35 +119,47 @@ main(int argc, char *argv[])
 
         }
 
-    } catch (char * err) {
-
-    }
-    //----------------------------------------
+    } catch (char * err) { }
 
     return 0;
 
-//	clearScreen();
-//	std::cout << "VIRTUAL KVM" << std::endl;
-//
-//	while(1)
-//	{
-//		int n = RS232_PollComport(port, buf, size - 1);
-//		if (n > 0) {
-//			buf[n] = 0;
-//			for(int i = 0; i < n; i++) {
-//				if(buf[i] < 32) {
-//					buf[i] = '.';
-//				}
-//			}
-//			i++;
-//		}
-//		if (i > 20) {
-//			clearScreen();
-//			std::cout << "VIRTUAL KVM" << std::endl;
-//
-//			ToggleDevices();
-//			i = 0;
-//		}
-//	}
-//	return 0;
+#else
+	if(RS232_OpenComport(port, baudRate, mode))
+	{
+		std::cout << "Could not access serial port!\nDid you run as root?" << std::endl;
+		return 1;
+	}
+	if ( popenCmd ( "sudo virsh list --all | grep " + vmName ).find ( "shut off" ) != std::string::npos ) {
+		for(int i = 0; i < argc; i++) {
+			if(argv[i] == "--daemonize") {
+				std::cout << "[*] ERROR: VM \'" + vmName + "\' is not running.";
+				return 1;
+			}
+		}
+	}
+	clearScreen();
+	std::cout << "VIRTUAL KVM" << std::endl;
+
+	while(1)
+	{
+		int n = RS232_PollComport(port, buf, size - 1);
+		if (n > 0) {
+			buf[n] = 0;
+			for(int i = 0; i < n; i++) {
+				if(buf[i] < 32) {
+					buf[i] = '.';
+				}
+			}
+			i++;
+		}
+		if (i > 20) {
+			clearScreen();
+			std::cout << "VIRTUAL KVM" << std::endl;
+
+			ToggleDevices();
+			i = 0;
+		}
+	}
+	return 0;
+#endif
 }

--- a/virtkvm_client.py
+++ b/virtkvm_client.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import socket
+
+# This file connects to the server at the specified port and ip address. After connecting, this program sends the
+# command "toggle" and immediately disconnects and terminates. It's reccomeneded to map a hotkey to run this program,
+# and then that hotkey would appear to be a kvm toggle switch
+
+HOST = "192.168.122.1"
+PORT = 5555
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.connect((HOST, PORT))
+s.sendall(b'toggle')
+s.close()


### PR DESCRIPTION
Compiled as originally specified, none of these changes see the light of day. However, with a couple of compiler arguments, this added code will listen on a TCP port instead of RS232. Whenever anyone "pings" that port (ie sends the command "toggle" to it), virtkvm will toggle the peripherals.